### PR TITLE
Don' use obsoleted API

### DIFF
--- a/java-imports.el
+++ b/java-imports.el
@@ -115,7 +115,7 @@ already-existing class name."
                   (string< (java-import-for-line) full-name))
         (forward-line 1))
       (open-line 1)
-      (insert-string "import " full-name ";")
+      (insert "import " full-name ";")
       ;; Now we may need to add empty lines
       (forward-line 1)
       (when (not (java-import-for-line))


### PR DESCRIPTION
Use 'insert' instead of 'insert-string' because 'insert-string' was
an obsoleted function since Emacs 22.1.

There is a byte-compile warning about this.

```
In import-java-class:
java-imports.el:124:12:Warning: `insert-string' is an obsolete function (as of
    22.1); use `insert' instead
```