### PR TITLE
Include top level type declarations in java-imports-scan-file

### DIFF
--- a/test/java-imports-test.el
+++ b/test/java-imports-test.el
@@ -120,6 +120,100 @@
       (java-imports-list-imports)
       '("org.Thing" "java.util.List" "java.util.ArrayList")))))
 
+(ert-deftest t-list-top-levels ()
+  (with-temp-buffer
+    (insert "package mypackage;\n")
+    (insert "\n")
+    (insert "import org.Thing;\n")
+    (insert "\n")
+    (insert "import java.util.List;\n")
+    (insert "import java.util.ArrayList;\n")
+    (insert "\n")
+    (insert "public class Foo {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("mypackage.Foo"))))
+
+  (with-temp-buffer
+    (insert "public class Foo {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("Foo"))))
+
+  (with-temp-buffer
+    (insert "public abstract class Foo {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("Foo"))))
+
+  (with-temp-buffer
+    (insert "public class Foo extends Bar {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("Foo"))))
+
+  (with-temp-buffer
+    (insert "public class Foo implements Bar {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("Foo"))))
+
+  (with-temp-buffer
+    (insert "public class Foo<T> {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("Foo"))))
+
+  (with-temp-buffer
+    (insert "package mypackage;\n")
+    (insert "\n")
+    (insert "class Foo {\n")
+    (insert "public static class Bar {}\n")
+    (insert "}\n")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '())))
+
+  (with-temp-buffer
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '())))
+
+  (with-temp-buffer
+    (insert "package mypackage;\n")
+    (insert "\n")
+    (insert "public\nenum\nFoo\n{}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("mypackage.Foo"))))
+
+  (with-temp-buffer
+    (insert "package mypackage;\n")
+    (insert "\n")
+    (insert "public @interface Annotation {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("mypackage.Annotation"))))
+
+  (with-temp-buffer
+    (insert "package mypackage;\n")
+    (insert "\n")
+    (insert "public interface Foo {}")
+    (should
+     (equal
+      (java-imports-list-top-levels)
+      '("mypackage.Foo")))))
+
 (ert-deftest t-pkg-and-class-from-import ()
   (should
    (equal (java-imports-get-package-and-class "java.util.Map")
@@ -158,7 +252,11 @@
             (should
              (equal
               (pcache-get cache 'ArrayList)
-              "java.util"))))
+              "java.util"))
+            (should
+             (equal
+              (pcache-get cache 'Foo)
+              "mypackage"))))
       (pcache-destroy-repository java-imports-cache-name))))
 
 ;; End:


### PR DESCRIPTION
Add new function java-imports-list-top-level and use it in java-imports-scan-file to add public top level types to list of classes to add to cache.

I find it useful when creating a new type or when opening a project for the first time to automatically get top level types added to the cache instead of having to import it at least once first.

Only works if java-imports-scan-file runs after type is declared in file so for new files it might be worth adding (java-imports-scan-file) to define-auto-insert for example.
    
No kotlin-mode support yet, haven't figured out a good way to do a "negative" match as "public" modifier is the default in kotlin. Also the primary constructor syntax is tricky to include and the regex is already rather horrible.